### PR TITLE
Refactors templates for precursor data

### DIFF
--- a/inst/quarto_template/Template_DIA-NN_peptide_dev.qmd
+++ b/inst/quarto_template/Template_DIA-NN_peptide_dev.qmd
@@ -1,5 +1,5 @@
 ---
-title: "DE Analysis Report (Peptide): `r params$title`"
+title: "DE Analysis Report (Precursor): `r params$title`"
 subtitle: "`r params$subtitle`"
 author: "`r params$author`"
 format: 
@@ -232,25 +232,24 @@ if ( ! is_empty(params$confounder_list) ) {
 ## Normalization
 
 Normalization of the precursor intensities are:
-
--   Precursor  with the same peptide sequences are **summed** toghether at peptide level  
--   Peptide intensities are log transformed and then normalized using **`r params$normalization`** approach.
+ 
+-   Precursor intensities are log transformed and then normalized using **`r params$normalization`** approach.
 
 After all the step, the quantitaive features used in the downstream analysis are:
 
-- Number of peptide identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
+- Number of precursor identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
 
 ```{r normalization_plot}
 
 if ( 'peptideLog' %in% names(pe)){
 par(mfrow=c(1,3))
-limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Peptide log-tranformed') 
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' )
+limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw precursor')
+limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Precursor log-tranformed') 
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' )
 }else{
   par(mfrow=c(1,2))
- limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' ) 
+ limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw peptide')
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' ) 
 }
 
 
@@ -260,7 +259,7 @@ limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Norma
 
 ## Data Missing Analysis
 
-The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis peptides/proteins are ordered based on the increasing NA content.
+The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis precursor are ordered based on the increasing NA content.
 
 ```{r missing_val_analysis}
 
@@ -268,7 +267,7 @@ pdf(NULL)
   peptidemissingness <- MSnbase::plotNA(assay(pe[["peptideNorm"]]))
 invisible(dev.off())
 
-peptidemissingness <-  peptidemissingness + xlab("Peptide index (ordered by data completeness)") +
+peptidemissingness <-  peptidemissingness + xlab("Precursor index (ordered by data completeness)") +
   theme_bw() +
   theme(legend.position = "none") +
   theme(strip.text.x = element_blank(),
@@ -284,7 +283,7 @@ peptidemissingness
 
 ## Completeness Analysis 
 
-This section analyzes the completeness of peptide readouts across all samples within each group. For each quantified peptide, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
+This section analyzes the completeness of precursor readouts across all samples within each group. For each quantified precursor, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
 
 ```{r completeness_analysis}
 log_info('Completness Analysis...')
@@ -423,7 +422,7 @@ log_info('Running Analysis for each comparison..')
    
 
     if ( dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1] <= 5 || dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1]  >=  50     ){
-      cat(' Not enough DE peptides (< 5) or too many DE peptides for heatmap visualization \n')
+      cat(' Not enough DE precursor (< 5) or too many DE precursor for heatmap visualization \n')
     }else{
       
     #filt_val <- unlist(str_split(substring(gsub(params$contrast, ' ', (gsub(' - ','',cmp))), 2),' ' ))
@@ -443,7 +442,7 @@ log_info('Running Analysis for each comparison..')
     cat('\n\n')
     cat('\n\n')
     cat('\n\n')
-    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of proteins based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
+    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of precursor based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
    
     diareport::render_child(data = res_de[[cmp]],
                  pe =pe,
@@ -460,9 +459,9 @@ log_info('Running Analysis for each comparison..')
 
 
 
-## Summary of the DE proteins
+## Summary of the DE precursor
 
-In the table you can find a summaries of the number of DE proteins found in all the comparisons. The overlapping of DE proteins among the comparisons is also showed using an upset plot.
+In the table you can find a summaries of the number of DE precursor found in all the comparisons. The overlapping of DE precursor among the comparisons is also showed using an upset plot.
 
 ```{r upset plot}
 log_info('DE Summary computation...')

--- a/inst/quarto_template/Template_DIA-NN_peptide_dev_A.qmd
+++ b/inst/quarto_template/Template_DIA-NN_peptide_dev_A.qmd
@@ -1,5 +1,5 @@
 ---
-title: "DE Analysis Report (Peptide): `r params$title`"
+title: "DE Analysis Report (Precursor): `r params$title`"
 subtitle: "`r params$subtitle`"
 author: "`r params$author`"
 format: 
@@ -237,24 +237,23 @@ if ( ! is_empty(params$confounder_list) ) {
 
 Normalization of the precursor intensities are:
 
--   Precursor  with the same peptide sequences are **summed** toghether at peptide level  
--   Peptide intensities are log transformed and then normalized using **`r params$normalization`** approach.
+-   Precursor intensities are log transformed and then normalized using **`r params$normalization`** approach.
 
 After all the step, the quantitaive features used in the downstream analysis are:
 
-- Number of peptide identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
+- Number of precursor identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
 
 ```{r normalization_plot}
 
 if ( 'peptideLog' %in% names(pe)){
 par(mfrow=c(1,3))
-limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Peptide log-tranformed') 
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' )
+limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw precursor')
+limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Precursor log-tranformed') 
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' )
 }else{
   par(mfrow=c(1,2))
- limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' ) 
+ limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw peptide')
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' ) 
 }
 
 
@@ -264,7 +263,7 @@ limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Norma
 
 ## Data Missing Analysis
 
-The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis peptides/proteins are ordered based on the increasing NA content.
+The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis precursor are ordered based on the increasing NA content.
 
 ```{r missing_val_analysis}
 
@@ -272,7 +271,7 @@ pdf(NULL)
   peptidemissingness <- MSnbase::plotNA(assay(pe[["peptideNorm"]]))
 invisible(dev.off())
 
-peptidemissingness <-  peptidemissingness + xlab("Peptide index (ordered by data completeness)") +
+peptidemissingness <-  peptidemissingness + xlab("Precursor index (ordered by data completeness)") +
   theme_bw() +
   theme(legend.position = "none") +
   theme(strip.text.x = element_blank(),
@@ -301,7 +300,7 @@ DT::datatable( as.data.frame(nNA(pe[["peptideNorm"]])$nNAcols) %>% rename(  Samp
 
 ## Completeness Analysis 
 
-This section analyzes the completeness of peptide readouts across all samples within each group. For each quantified peptide, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
+This section analyzes the completeness of precursor readouts across all samples within each group. For each quantified precursor, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
 
 ```{r completeness_analysis}
 log_info('Completness Analysis...')
@@ -443,7 +442,7 @@ log_info('Running Analysis for each comparison..')
    
 
     if ( dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1] <= 5 || dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1]  >=  50     ){
-      cat(' Not enough DE peptides (< 5) or too many DE peptides for heatmap visualization \n')
+      cat(' Not enough DE precursor (< 5) or too many DE precursor for heatmap visualization \n')
     }else{
       
     #filt_val <- unlist(str_split(substring(gsub(params$contrast, ' ', (gsub(' - ','',cmp))), 2),' ' ))
@@ -466,12 +465,12 @@ log_info('Running Analysis for each comparison..')
     cat('\n\n')
     cat('###','Absent-from-DE Analysis')
     cat('\n\n')
-    cat ('All proteins that are either uniquely present or absent in one of the two groups, and are not included in the differential expression (DE) results, are listed below. A heatmap displayed above the table illustrates the peptides intensities across all replicates for the two groups of interest. \n')
+    cat ('All precursor that are either uniquely present or absent in one of the two groups, and are not included in the differential expression (DE) results, are listed below. A heatmap displayed above the table illustrates the precursor intensities across all replicates for the two groups of interest. \n')
     ### partial analysis result visualition   
     
     if (dim( res_part_item[[cmp]])[1]==0){
        cat('\n\n')
-       cat('No peptides present.')
+       cat('No precursor present.')
        cat('\n\n')
       }else{
          diareport::render_child(data = res_part_item[[cmp]],
@@ -490,7 +489,7 @@ log_info('Running Analysis for each comparison..')
     cat('\n\n')
     cat('\n\n')
     cat('\n\n')
-    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of proteins based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
+    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of precursor based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
    
     diareport::render_child(data = res_de[[cmp]],
                  pe =pe,
@@ -507,9 +506,9 @@ log_info('Running Analysis for each comparison..')
 
 
 
-## Summary of the DE proteins
+## Summary of the DE precursor
 
-In the table you can find a summaries of the number of DE proteins found in all the comparisons. The overlapping of DE proteins among the comparisons is also showed using an upset plot.
+In the table you can find a summaries of the number of DE precursor found in all the comparisons. The overlapping of DE precursor among the comparisons is also showed using an upset plot.
 
 ```{r upset plot}
 log_info('DE Summary computation...')

--- a/inst/quarto_template/Template_DIA-NN_peptide_dev_EV.qmd
+++ b/inst/quarto_template/Template_DIA-NN_peptide_dev_EV.qmd
@@ -1,5 +1,5 @@
 ---
-title: "DE Analysis Report (Peptide): `r params$title`"
+title: "DE Analysis Report (Precursor): `r params$title`"
 subtitle: "`r params$subtitle`"
 author: "`r params$author`"
 format: 
@@ -335,24 +335,23 @@ print(plot_perc)
 
 Normalization of the precursor intensities are:
 
--   Precursor  with the same peptide sequences are **summed** toghether at peptide level  
--   Peptide intensities are log transformed and then normalized using **`r params$normalization`** approach.
+-   Precursor intensities are log transformed and then normalized using **`r params$normalization`** approach.
 
 After all the step, the quantitaive features used in the downstream analysis are:
 
-- Number of peptide identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
+- Number of precursor identified/quantified is : **`{r} dim(assay(pe[['peptideNorm']]))[1]`**
 
 ```{r normalization_plot}
 
 if ( 'peptideLog' %in% names(pe)){
 par(mfrow=c(1,3))
-limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Peptide log-tranformed') 
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' )
+limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw precursor')
+limma::plotDensities(assay(pe[["peptideLog"]]),legend=FALSE,main='Precursor log-tranformed') 
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' )
 }else{
   par(mfrow=c(1,2))
- limma::plotDensities(assay(pe[["PeptideRawSum"]]),legend=FALSE,main='Raw peptide')
-limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Normalized' ) 
+ limma::plotDensities(assay(pe[["precursor"]]),legend=FALSE,main='Raw peptide')
+limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Precursor Normalized' ) 
 }
 
 
@@ -362,7 +361,7 @@ limma::plotDensities(assay(pe[["peptideNorm"]]),legend=FALSE,main='Peptide Norma
 
 ## Data Missing Analysis
 
-The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis peptides/proteins are ordered based on the increasing NA content.
+The plot shows the completeness of the experiments at precursor and summarized level. On the the x-axis Precursor are ordered based on the increasing NA content.
 
 ```{r missing_val_analysis}
 
@@ -370,7 +369,7 @@ pdf(NULL)
   peptidemissingness <- MSnbase::plotNA(assay(pe[["peptideNorm"]]))
 invisible(dev.off())
 
-peptidemissingness <-  peptidemissingness + xlab("Peptide index (ordered by data completeness)") +
+peptidemissingness <-  peptidemissingness + xlab("Precursor index (ordered by data completeness)") +
   theme_bw() +
   theme(legend.position = "none") +
   theme(strip.text.x = element_blank(),
@@ -399,7 +398,7 @@ DT::datatable( as.data.frame(nNA(pe[["peptideNorm"]])$nNAcols) %>% rename(  Samp
 
 ## Completeness Analysis 
 
-This section analyzes the completeness of peptide readouts across all samples within each group. For each quantified peptide, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
+This section analyzes the completeness of precursor readouts across all samples within each group. For each quantified precursor, a completeness percentage is calculated based on the proportion of missing values across all samples in the group. These percentages are compared between the groups in the lower diagonal. On the diagonal, a histogram illustrates the distribution of detection percentages for each group
 
 ```{r completeness_analysis}
 log_info('Completness Analysis...')
@@ -583,7 +582,7 @@ log_info('Running Analysis for each comparison..')
    
 
     if ( dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1] <= 5 || dim(res_de[[cmp]]$toptable %>% filter(differential_expressed %in% c('UP','DOWN')) )[1]  >=  50     ){
-      cat(' Not enough DE peptides (< 5) or too many DE peptides for heatmap visualization \n')
+      cat(' Not enough DE precursor (< 5) or too many DE precursor for heatmap visualization \n')
     }else{
       
     #filt_val <- unlist(str_split(substring(gsub(params$contrast, ' ', (gsub(' - ','',cmp))), 2),' ' ))
@@ -606,7 +605,7 @@ log_info('Running Analysis for each comparison..')
     cat('\n\n')
     cat('###','Absent-from-DE Analysis')
     cat('\n\n')
-    cat ('All proteins that are either uniquely present or absent in one of the two groups, and are not included in the differential expression (DE) results, are listed below. A heatmap displayed above the table illustrates the peptides intensities across all replicates for the two groups of interest. \n')
+    cat ('All precursor that are either uniquely present or absent in one of the two groups, and are not included in the differential expression (DE) results, are listed below. A heatmap displayed above the table illustrates the precursor intensities across all replicates for the two groups of interest. \n')
     ### partial analysis result visualition   
     
     if (dim( res_part_item[[cmp]])[1]==0){
@@ -630,7 +629,7 @@ log_info('Running Analysis for each comparison..')
     cat('\n\n')
     cat('\n\n')
     cat('\n\n')
-    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of proteins based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
+    cat('These bar plots summarizes the number of significantly upregulated/downregulated number of precursor based on different adjusted p-values (selected adjusted p-values are 0.001, 0.01, 0.05, and 0.1 - see facet headers) and log2 fold-change thresholds (on the x-axis) used to define the significance levels.')
    
     diareport::render_child(data = res_de[[cmp]],
                  pe =pe,
@@ -647,9 +646,9 @@ log_info('Running Analysis for each comparison..')
 
 
 
-## Summary of the DE proteins
+## Summary of the DE precursor
 
-In the table you can find a summaries of the number of DE proteins found in all the comparisons. The overlapping of DE proteins among the comparisons is also showed using an upset plot.
+In the table you can find a summaries of the number of DE precursor found in all the comparisons. The overlapping of DE precursor among the comparisons is also showed using an upset plot.
 
 ```{r upset plot}
 log_info('DE Summary computation...')

--- a/inst/quarto_template/_templateContrast_Peptide.Rmd
+++ b/inst/quarto_template/_templateContrast_Peptide.Rmd
@@ -1,7 +1,7 @@
 
 ```{r}
 
-log_info('Inside Contrast Visual for Peptide.... ')
+log_info('Inside Contrast Visual for Precursor.... ')
 
 label_work <- gsub('Group','',label)
   label_work_f <- gsub(' ','_',label_work)
@@ -47,8 +47,8 @@ UP <- dim(data$toptable %>% filter(differential_expressed == 'UP'))[1]
 DOWN <-  dim(data$toptable %>% filter(differential_expressed == 'DOWN'))[1]
  
 if ( UP > 0 | DOWN > 0   ) { 
-  log_info('DE peptides found')
-  cat('Boxplot intensities of the top 10 DE peptides ordered by log2FC')
+  log_info('DE precursor found')
+  cat('Boxplot intensities of the top 10 DE precursor ordered by log2FC')
     ## peptide
     d_l <- data$toptable %>% filter(differential_expressed == 'DOWN') %>% 
             arrange(logFC) %>% head(5)%>%   pull(precursor_id)
@@ -87,7 +87,7 @@ if ( UP > 0 | DOWN > 0   ) {
     geom_boxplot() +
     scale_fill_manual( values= c( "#6d0286", "#35B779FF") ) +
     geom_jitter(color="black", size=1, alpha=0.8)  +
-     ylab('Peptide Intensity') +
+     ylab('Precursor Intensity') +
      xlab(NULL) +
      theme(axis.text.x = element_blank(),
         axis.ticks.x = element_blank(),

--- a/inst/quarto_template/_templatePartialResult.Rmd
+++ b/inst/quarto_template/_templatePartialResult.Rmd
@@ -39,7 +39,7 @@ if (dim(part_int)[1] < 50 ){
     width = 1200 , height =900 ,   
     cexRow = 1, cexCol = 0.8 , file =  file.path(path,paste0("Exclusive_protein_Heatmap_",".pdf")))   
     }else{
-    cat ('Too many peptide / proteins for heatmap visualization')
+    cat ('Too many precursor / protein for heatmap visualization')
 }
 
  


### PR DESCRIPTION
Move to peptide to precursor workflow
Updates labels in templates to accurately reflect that the analysis is performed on precursor data rather than peptide data.

Ensures consistency and clarity in the template reports.

this take into account suggestion in https://github.com/Gevaert-Lab/diareport/issues/2, to move peptide analysis into precursor analysis